### PR TITLE
Make ExpandablePageLayout#pullToCollapseInterceptor nullable 

### DIFF
--- a/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/ExpandablePageLayout.kt
+++ b/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/ExpandablePageLayout.kt
@@ -103,9 +103,10 @@ open class ExpandablePageLayout @JvmOverloads constructor(
   }
 
   override fun onDetachedFromWindow() {
-    pullToCollapseInterceptor = null
     parentToolbar = null
     nestedPage = null
+    pullToCollapseInterceptor = null
+    pullToCollapseListener.removeAllOnPullListeners()
     internalStateCallbacksForNestedPage = InternalPageCallbacks.NoOp()
     internalStateCallbacksForRecyclerView = InternalPageCallbacks.NoOp()
     stateChangeCallbacks.clear()

--- a/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/ExpandablePageLayout.kt
+++ b/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/ExpandablePageLayout.kt
@@ -87,7 +87,7 @@ open class ExpandablePageLayout @JvmOverloads constructor(
     changeState(PageState.COLLAPSED)
 
     pullToCollapseEnabled = true
-    pullToCollapseListener = PullToCollapseListener(getContext(), this)
+    pullToCollapseListener = PullToCollapseListener(this)
     pullToCollapseListener.addOnPullListener(this)
   }
 

--- a/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/OnPullToCollapseInterceptor.kt
+++ b/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/OnPullToCollapseInterceptor.kt
@@ -21,4 +21,8 @@ package me.saket.inboxrecyclerview.page
  */
 typealias OnPullToCollapseInterceptor = (downX: Float, downY: Float, upwardPull: Boolean) -> InterceptResult
 
+@Deprecated(
+    message = "ExpandablePageLayout#pullToCollapseInterceptor is now nullable so this is no longer required",
+    replaceWith = ReplaceWith("null")
+)
 val IGNORE_ALL_PULL_TO_COLLAPSE_INTERCEPTOR : OnPullToCollapseInterceptor = { _, _, _ -> InterceptResult.IGNORED }

--- a/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/PullToCollapseListener.kt
+++ b/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/PullToCollapseListener.kt
@@ -56,6 +56,10 @@ class PullToCollapseListener(context: Context, private val expandablePage: Expan
     onPullListeners.remove(listener)
   }
 
+  fun removeAllOnPullListeners() {
+    onPullListeners.clear()
+  }
+
   @SuppressLint("ClickableViewAccessibility")
   override fun onTouch(v: View, event: MotionEvent): Boolean {
     when (event.actionMasked) {

--- a/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/PullToCollapseListener.kt
+++ b/inboxrecyclerview/src/main/java/me/saket/inboxrecyclerview/page/PullToCollapseListener.kt
@@ -7,12 +7,15 @@ import android.view.View
 import android.view.ViewConfiguration
 import java.util.ArrayList
 
-class PullToCollapseListener(context: Context, private val expandablePage: ExpandablePageLayout) : View.OnTouchListener {
+class PullToCollapseListener(private val expandablePage: ExpandablePageLayout) : View.OnTouchListener {
+
+  @Deprecated(message = "Passing context is no longer needed")
+  constructor(context: Context, expandablePage: ExpandablePageLayout) : this(expandablePage)
 
   /** Minimum Y-distance the page has to be pulled before it's eligible for collapse. */
   var collapseDistanceThreshold: Int = 0
 
-  private val touchSlop: Int = ViewConfiguration.get(context).scaledTouchSlop
+  private val touchSlop: Int = ViewConfiguration.get(expandablePage.context).scaledTouchSlop
   private val onPullListeners = ArrayList<OnPullListener>(3)
   private var downX: Float = 0F
   private var downY: Float = 0F

--- a/sample/src/main/java/me/saket/inboxrecyclerview/sample/email/EmailThreadFragment.kt
+++ b/sample/src/main/java/me/saket/inboxrecyclerview/sample/email/EmailThreadFragment.kt
@@ -64,13 +64,14 @@ class EmailThreadFragment : Fragment() {
     emailThreadPage.pullToCollapseInterceptor = { downX, downY, upwardPull ->
       if (scrollableContainer.globalVisibleRect().contains(downX, downY).not()) {
         InterceptResult.IGNORED
-      }
 
-      val directionInt = if (upwardPull) +1 else -1
-      val canScrollFurther = scrollableContainer.canScrollVertically(directionInt)
-      when {
-        canScrollFurther -> InterceptResult.INTERCEPTED
-        else -> InterceptResult.IGNORED
+      } else {
+        val directionInt = if (upwardPull) +1 else -1
+        val canScrollFurther = scrollableContainer.canScrollVertically(directionInt)
+        when {
+          canScrollFurther -> InterceptResult.INTERCEPTED
+          else -> InterceptResult.IGNORED
+        }
       }
     }
 


### PR DESCRIPTION
This should make it easier for library users to unregister the interceptor if needed.